### PR TITLE
Add Hint and FragmentWeb components for enhanced user interaction

### DIFF
--- a/src/components/hint.tsx
+++ b/src/components/hint.tsx
@@ -1,0 +1,33 @@
+"use client";
+
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
+
+interface HintProps {
+    children: React.ReactNode;
+    text: string;
+    side?: "top" | "right" | "bottom" | "left";
+    align?: "start" | "center" | "end";
+}
+
+export const Hint = ({ 
+    children, 
+    text, 
+    side = "bottom", 
+    align = "center" 
+    }: HintProps) => {
+    
+    
+    
+    return (
+        <TooltipProvider>
+            <Tooltip>
+                <TooltipTrigger asChild>
+                    {children}
+                </TooltipTrigger>
+                <TooltipContent side={side} align={align}>
+                    <p>{text}</p>
+                </TooltipContent>
+            </Tooltip>
+        </TooltipProvider>
+    );
+};

--- a/src/modules/projects/ui/components/fragment-web.tsx
+++ b/src/modules/projects/ui/components/fragment-web.tsx
@@ -1,0 +1,71 @@
+import { Fragment } from '@prisma/client';
+import { useState } from 'react';
+import { ExternalLinkIcon, RefreshCwIcon } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Hint } from '@/components/hint';
+
+interface Props {
+    data: Fragment;
+};
+
+export const FragmentWeb = ({ data }: Props) => {
+    
+    const [copied, setCopied] = useState(false);
+    const [fragmentKey, setFragmentKey] = useState(0);
+
+    const onRefresh =() => {
+        setFragmentKey((prev) => prev + 1);
+    };
+
+    const handleCopy = () => {
+        navigator.clipboard.writeText(data.sandboxUrl);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+        };
+   
+    
+    return (
+
+        <div className="flex flex-col w-full h-full" >
+            <div className="p-2 border-b bg-sidebar flex items-center gap-x-2">
+            <Hint text="Refresh" side="bottom" align="start">
+                <Button size="sm" variant="outline" onClick={onRefresh}>
+                    <RefreshCwIcon />
+                </Button>
+                </Hint>
+                <Hint text="Refresh" side="bottom" align="start">
+                <Button 
+                size="sm" 
+                variant="outline" 
+                onClick={handleCopy}
+                disabled={!data.sandboxUrl || copied}
+                className="flex-1 justify-start text-start font-normal"
+                >
+                    <span className="truncate"> 
+                        {data.sandboxUrl}
+                     </span>
+                </Button>
+                </Hint>
+                <Hint text="Open in new tab" side="bottom" align="start">
+                <Button 
+                size="sm" 
+                variant="outline" 
+                onClick={() => { 
+                    if (!data.sandboxUrl) return;
+                    window.open(data.sandboxUrl, "_blank");
+                }}
+                >
+                    <ExternalLinkIcon />
+                </Button>
+                </Hint>
+            </div>
+            <iframe
+                key={fragmentKey}
+                className="w-full h-full"
+                sandbox="allow-forms allow-scripts allow-same-origin"
+                loading="lazy"
+                src={data.sandboxUrl}
+            />
+        </div>
+    );
+};

--- a/src/modules/projects/ui/views/project-view.tsx
+++ b/src/modules/projects/ui/views/project-view.tsx
@@ -8,6 +8,7 @@ import { Fragment } from "@prisma/client";  // This may be wrong , it's supposed
 import { MessagesContainer } from "@/modules/projects/ui/components/messages-container";
 import { Suspense, useState } from "react";
 import { ProjectHeader } from "../components/project-header";
+import { FragmentWeb } from "../components/fragment-web";
 
 interface Props {
     projectId: string;
@@ -42,7 +43,7 @@ export const ProjectView = ({ projectId }: Props) => {
             defaultSize={65}
             minSize={50}
             >
-            TODO: Preview 
+            {!!activeFragment && <FragmentWeb data={activeFragment}/> }
             </ResizablePanel>
             </ResizablePanelGroup>
         </div>


### PR DESCRIPTION
- Introduced `Hint` component to provide contextual tooltips for user actions, improving usability.
- Added `FragmentWeb` component to display project fragments with copy and refresh functionality, enhancing project management.
- Integrated `Hint` tooltips into buttons for better user guidance on actions like refreshing, copying URLs, and opening links in new tabs.

This commit enhances the overall user experience by providing informative tooltips and improving the functionality of project fragment interactions.